### PR TITLE
handle empty dir symlink that needs to be removed

### DIFF
--- a/lib/symlink.js
+++ b/lib/symlink.js
@@ -31,8 +31,9 @@ function buildLinkPaths(libraries, symlinkPath) {
 function symLink(paths, callback) {
   try {
     paths.forEach(function(p) {
-      if (fs.lstatSync(p[0]).isDirectory() || fs.lstatSync(p[0]).isSymbolicLink()){
-        fse.copySync(p[0], p[1], {overwrite:true, filter: filterFunc });
+      var stat = fs.lstatSync(p[0]); 
+      if (stat.isDirectory() || stat.isSymbolicLink){
+        fse.copySync(p[0], p[1], {overwrite:true, filter: filterFunc});
         log.info('Symlinked: ', p[0], 'to ', p[1]);
       }
     });

--- a/lib/symlink.js
+++ b/lib/symlink.js
@@ -8,7 +8,7 @@ var filterFunc = function(src, dest) {
   } else {
     var lsync = fs.lstatSync(src);
     if (lsync.isSymbolicLink() || lsync.isFile()) {
-      if (fs.existsSync(dest)){
+      if (fs.existsSync(dest) || lsync.isSymbolicLink()){
         fse.removeSync(dest);
       }
       fs.symlinkSync(src, dest);

--- a/lib/symlink.js
+++ b/lib/symlink.js
@@ -3,8 +3,6 @@ var fse = require('fs-extra');
 var log = require('npmlog');
 
 var filterFunc = function(src, dest) {
-  console.log('filter func')
-
   if (src.indexOf('mason.ini') > -1) {
     return false;
   } else {

--- a/lib/symlink.js
+++ b/lib/symlink.js
@@ -3,6 +3,8 @@ var fse = require('fs-extra');
 var log = require('npmlog');
 
 var filterFunc = function(src, dest) {
+  console.log('filter func')
+
   if (src.indexOf('mason.ini') > -1) {
     return false;
   } else {
@@ -31,7 +33,7 @@ function buildLinkPaths(libraries, symlinkPath) {
 function symLink(paths, callback) {
   try {
     paths.forEach(function(p) {
-      if (fs.lstatSync(p[0]).isDirectory()){
+      if (fs.lstatSync(p[0]).isDirectory() || fs.lstatSync(p[0]).isSymbolicLink()){
         fse.copySync(p[0], p[1], {overwrite:true, filter: filterFunc });
         log.info('Symlinked: ', p[0], 'to ', p[1]);
       }

--- a/lib/symlink.js
+++ b/lib/symlink.js
@@ -6,9 +6,8 @@ var filterFunc = function(src, dest) {
   if (src.indexOf('mason.ini') > -1) {
     return false;
   } else {
-    var lsync = fs.lstatSync(src);
-    if (lsync.isSymbolicLink() || lsync.isFile()) {
-      if (fs.existsSync(dest) || lsync.isSymbolicLink()){
+    if (filterFunc.lsync.isSymbolicLink() || filterFunc.lsync.isFile()) {
+      if (fs.existsSync(dest) || filterFunc.lsync.isSymbolicLink()){
         fse.removeSync(dest);
       }
       fs.symlinkSync(src, dest);
@@ -31,11 +30,14 @@ function buildLinkPaths(libraries, symlinkPath) {
 function symLink(paths, callback) {
   try {
     paths.forEach(function(p) {
-      var stat = fs.lstatSync(p[0]); 
-      if (stat.isDirectory() || stat.isSymbolicLink){
+      var lsync = fs.lstatSync(p[0]); 
+      filterFunc.lsync = lsync; 
+
+      if (lsync.isDirectory() || lsync.isSymbolicLink()){
         fse.copySync(p[0], p[1], {overwrite:true, filter: filterFunc});
         log.info('Symlinked: ', p[0], 'to ', p[1]);
       }
+
     });
     return callback(null, true);
   } catch (e) {

--- a/test/file_handler.test.js
+++ b/test/file_handler.test.js
@@ -116,8 +116,8 @@ test('[mason-js] missing package type', function(assert) {
 test('[add package to file] adds header package to mason-versions.ini', function(assert) {
   var src = path.join(__dirname + '/fixtures/', 'fake-mason-versions.ini');
   var dst = path.join(__dirname + '/fixtures/out', 'fake-mason-versions.ini');
-  fs.writeFileSync(src, '');
-  fs.writeFileSync(dst, '');
+  var content = fs.readFileSync(src);
+  fs.writeFileSync(dst, content);
 
   var package = 'crazynewpackage=1.5.1';
   var type = 'header';

--- a/test/file_handler.test.js
+++ b/test/file_handler.test.js
@@ -116,8 +116,8 @@ test('[mason-js] missing package type', function(assert) {
 test('[add package to file] adds header package to mason-versions.ini', function(assert) {
   var src = path.join(__dirname + '/fixtures/', 'fake-mason-versions.ini');
   var dst = path.join(__dirname + '/fixtures/out', 'fake-mason-versions.ini');
-  var content = fs.readFileSync(src);
-  fs.writeFileSync(dst, content);
+  fs.writeFileSync(src, '');
+  fs.writeFileSync(dst, '');
 
   var package = 'crazynewpackage=1.5.1';
   var type = 'header';

--- a/test/symlink.test.js
+++ b/test/symlink.test.js
@@ -135,7 +135,7 @@ test('[symlink] overwrites existing files', function(assert) {
   });
 });
 
-test('[symlink] overwrites existing destination symlink with symlink source', function(assert) {
+test.only('[symlink] overwrites existing destination symlink with symlink source', function(assert) {
   var src = path.join(__dirname + '/fixtures/', 'fake', 'temp'); 
   var dst = path.join(__dirname + '/fixtures/', 'fake', 'tmp'); 
   

--- a/test/symlink.test.js
+++ b/test/symlink.test.js
@@ -154,7 +154,6 @@ test('[symlink] overwrites existing destination symlink with symlink source', fu
       assert.equal(err, null); 
       assert.equal(result, true);
       assert.equal(fse.removeSync.calledOnce, true, 'remove sync called once');
-      console.log('existsync', fs.existsSync);
       assert.equal(fs.existsSync.calledOnce, true);
       cleanUpSymlinks(function(){
         fs.existsSync.restore();

--- a/test/symlink.test.js
+++ b/test/symlink.test.js
@@ -153,7 +153,8 @@ test('[symlink] overwrites existing destination symlink with symlink source', fu
     link.symLink(paths, function(err, result) {
       assert.equal(err, null); 
       assert.equal(result, true);
-      assert.equal(fse.removeSync.calledOnce, true);
+      assert.equal(fse.removeSync.calledOnce, true, 'remove sync called once');
+      console.log('existsync', fs.existsSync);
       assert.equal(fs.existsSync.calledOnce, true);
       cleanUpSymlinks(function(){
         fs.existsSync.restore();

--- a/test/symlink.test.js
+++ b/test/symlink.test.js
@@ -135,7 +135,7 @@ test('[symlink] overwrites existing files', function(assert) {
   });
 });
 
-test.only('[symlink] overwrites existing destination symlink with symlink source', function(assert) {
+test('[symlink] overwrites existing destination symlink with symlink source', function(assert) {
   var src = path.join(__dirname + '/fixtures/', 'fake', 'temp'); 
   var dst = path.join(__dirname + '/fixtures/', 'fake', 'tmp'); 
   

--- a/test/symlink.test.js
+++ b/test/symlink.test.js
@@ -7,8 +7,8 @@ var fse = require('fs-extra');
 var appDir = process.cwd();
 var sinon = require('sinon');
 var log = require('npmlog');
-const firstSymSource = path.join(__dirname + '/fixtures/', 'symlink/');
-const secondSymSource = path.join(__dirname + '/fixtures/', 'symlink-copy/');
+var firstSymSource = path.join(__dirname + '/fixtures/', 'symlink/');
+var secondSymSource = path.join(__dirname + '/fixtures/', 'symlink-copy/');
   
 global.appRoot = process.cwd();
 
@@ -136,18 +136,18 @@ test('[symlink] overwrites existing files', function(assert) {
 });
 
 test('[symlink] overwrites existing destination symlink with symlink source', function(assert) {
-  const src = path.join(__dirname + '/fixtures/', 'fake', 'temp'); 
-  const dst = path.join(__dirname + '/fixtures/', 'fake', 'tmp'); 
+  var src = path.join(__dirname + '/fixtures/', 'fake', 'temp'); 
+  var dst = path.join(__dirname + '/fixtures/', 'fake', 'tmp'); 
   
-  const paths = [
+  var paths = [
     [src, dst]
   ];
 
   sinon.spy(fs, 'existsSync');
   sinon.spy(fse, 'removeSync');
 
-  setupSymlinks(function(err, result){
-    const lsync = fs.lstatSync(path.join(__dirname + '/fixtures/', 'fake', 'temp'));
+  setupSymlinks(function(){
+    var lsync = fs.lstatSync(path.join(__dirname + '/fixtures/', 'fake', 'temp'));
     assert.equal(lsync.isSymbolicLink(), true, 'src is symbolic link'); 
 
     link.symLink(paths, function(err, result) {
@@ -155,7 +155,7 @@ test('[symlink] overwrites existing destination symlink with symlink source', fu
       assert.equal(result, true);
       assert.equal(fse.removeSync.calledOnce, true);
       assert.equal(fs.existsSync.calledOnce, true);
-      cleanUpSymlinks(function(err, result){
+      cleanUpSymlinks(function(){
         fs.existsSync.restore();
         fse.removeSync.restore();
         assert.end();


### PR DESCRIPTION
In regards to #47, we didn't consider the case where an empty directory could be symlinked - this handles that case and adds a test. See original PR for this issue: https://github.com/mapbox/mason-js/pull/48